### PR TITLE
feat(duwi): Add Duwi integration

### DIFF
--- a/homeassistant/components/duwi/__init__.py
+++ b/homeassistant/components/duwi/__init__.py
@@ -1,0 +1,331 @@
+"""Support for Duwi Smart devices."""
+
+import asyncio
+import logging
+
+from duwi_smarthome_sdk.api.discover import DiscoverClient
+from duwi_smarthome_sdk.api.floor import FloorInfoClient
+from duwi_smarthome_sdk.api.room import RoomInfoClient
+from duwi_smarthome_sdk.api.terminal import TerminalClient
+from duwi_smarthome_sdk.api.ws import DeviceSynchronizationWS
+from duwi_smarthome_sdk.const.status import Code
+from duwi_smarthome_sdk.const.type_map import type_map
+
+from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    APP_VERSION,
+    CLIENT_MODEL,
+    CLIENT_VERSION,
+    DOMAIN,
+    SUPPORTED_PLATFORMS,
+)
+from .util import persist_messages_with_status_code, trans_duwi_state_to_ha_state
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, hass_config: dict) -> bool:
+    """
+    Set up the Duwi Smart Devices integration.
+
+    This method prepares the integration to be configured by checking for existing
+    config entries and initiating the config flow if none are found.
+
+    Parameters:
+    - hass: HomeAssistant instance.
+    - hass_config: Configuration dictionary.
+
+    Returns:
+    - Boolean indicating successful setup.
+    """
+
+    # Check for existing config entries for this integration
+    if not hass.config_entries.async_entries(DOMAIN):
+        # No entries found, initiate the configuration flow
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data={}
+            )
+        )
+
+    # Setup was successful
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """
+    Set up a Duwi Smart Hub config entry.
+
+    This method initializes the necessary data structures and starts the discovery
+    process using the DiscoverClient with the provided credentials from the config entry.
+
+    Parameters:
+    - hass: HomeAssistant instance for the current Home Assistant run.
+    - config_entry: ConfigEntry instance containing configuration data from the user.
+
+    Returns:
+    - True if the setup was successful.
+    """
+
+    # Extract the entry ID to use it as an instance identifier.
+    instance_id = config_entry.entry_id
+
+    # Create or ensure the primary domain data structure is present in hass.data.
+    hass.data.setdefault(DOMAIN, {})
+
+    # Clear old data for this instance, if any.
+    hass.data[DOMAIN].pop(instance_id, None)
+    terminals_dict = {}
+
+    hass.data[DOMAIN].setdefault(
+        instance_id,
+        {
+            "devices": {},  # Placeholder for devices dictionary to be populated
+        },
+    )
+
+    # Add the new house number to the list of existing houses.
+    hass.data[DOMAIN].setdefault("existing_house", []).append(
+        config_entry.data.get("house_no")
+    )
+
+    # Store the configuration entry data for easy access.
+    entry_data = hass.data[DOMAIN][instance_id]
+    entry_data.update(
+        {
+            "app_key": config_entry.data.get("app_key"),
+            "app_secret": config_entry.data.get("app_secret"),
+            "access_token": config_entry.data.get("access_token"),
+            "refresh_token": config_entry.data.get("refresh_token"),
+            "house_no": config_entry.data.get("house_no"),
+        }
+    )
+
+    # Initialize the client used for discovering devices with credentials from entry_data.
+    discover_client = DiscoverClient(
+        app_key=entry_data["app_key"],
+        app_secret=entry_data["app_secret"],
+        access_token=entry_data["access_token"],
+        app_version=APP_VERSION,
+        client_version=CLIENT_VERSION,
+        client_model=CLIENT_MODEL,
+    )
+
+    # Begin the discovery process using the discovery client.
+    status, devices = await discover_client.discover(house_no=entry_data["house_no"])
+
+    # Initialize clients for fetching floor, room, and terminal information.
+    floor_info_client = FloorInfoClient(
+        app_key=entry_data["app_key"],
+        app_secret=entry_data["app_secret"],
+        access_token=entry_data["access_token"],
+        app_version=APP_VERSION,
+        client_version=CLIENT_VERSION,
+        client_model=CLIENT_MODEL,
+    )
+
+    room_info_client = RoomInfoClient(
+        app_key=entry_data["app_key"],
+        app_secret=entry_data["app_secret"],
+        access_token=entry_data["access_token"],
+        app_version=APP_VERSION,
+        client_version=CLIENT_VERSION,
+        client_model=CLIENT_MODEL,
+    )
+
+    terminal_client = TerminalClient(
+        app_key=entry_data["app_key"],
+        app_secret=entry_data["app_secret"],
+        access_token=entry_data["access_token"],
+        app_version=APP_VERSION,
+        client_version=CLIENT_VERSION,
+        client_model=CLIENT_MODEL,
+    )
+
+    # Fetch additional data: floor, room, and terminal information.
+    floors_status, floors = await floor_info_client.fetch_floor_info(
+        entry_data["house_no"]
+    )
+    rooms_status, rooms = await room_info_client.fetch_room_info(entry_data["house_no"])
+    terminals_status, terminals = await terminal_client.fetch_terminal_info(
+        entry_data["house_no"]
+    )
+
+    if floors_status != Code.SUCCESS.value:
+        _LOGGER.error("Failed to fetch floor information")
+        floors = []
+
+    if rooms_status != Code.SUCCESS.value:
+        _LOGGER.error("Failed to fetch room information")
+        rooms = []
+
+    if terminals_status != Code.SUCCESS.value:
+        _LOGGER.error("Failed to fetch terminal information")
+        terminals = []
+
+    # Process terminal information for enhanced device accuracy.
+    if terminals is not None:
+        for terminal in terminals:
+            # Mapping of Host to Slave.
+            if terminal.host_sequence != terminal.terminal_sequence:
+                # Add this Slave into the Host's Slave list.
+                terminals_dict.setdefault(terminal.host_sequence, []).append(
+                    terminal.terminal_sequence
+                )
+                # Set the Slave's is_follow_online flag, whether the device will follow the slave online together.
+                hass.data[DOMAIN][instance_id].setdefault("slave", {}).setdefault(
+                    terminal.terminal_sequence,
+                    {"is_follow_online": terminal.is_follow_online},
+                )
+
+        hass.data[DOMAIN][instance_id].setdefault("host", terminals_dict)
+
+    # Create mapping dictionaries for floors and rooms for efficient data lookups.
+    floors_dict = (
+        {floor.floor_no: floor.floor_name for floor in floors} if floors else {}
+    )
+    rooms_floors_dict = {room.room_no: room.floor_no for room in rooms} if rooms else {}
+    rooms_dict = {room.room_no: room.room_name for room in rooms} if rooms else {}
+
+    # Assign floor and room names to each device based on the mapping.
+    for device in devices if devices else []:
+        device.floor_name = floors_dict.get(
+            rooms_floors_dict.get(device.room_no), device.floor_name
+        )
+        device.room_name = rooms_dict.get(device.room_no, device.room_name)
+
+    # Register devices within Home Assistant if the discovery was successful.
+    if status == Code.SUCCESS.value:
+        device_registry = setup_device_registry(devices)
+        hass.data[DOMAIN][instance_id]["devices"] = device_registry
+
+    # Forward the setup process to supported platforms within this integration.
+    await hass.config_entries.async_forward_entry_setups(
+        config_entry, SUPPORTED_PLATFORMS
+    )
+
+    # WebSocket callback for real-time device state updates.
+    async def on_callback(message: str):
+        await trans_duwi_state_to_ha_state(hass, instance_id, message)
+
+    # Initialize WebSocket for real-time synchronization.
+    ws_sync = DeviceSynchronizationWS(
+        on_callback=on_callback,
+        app_key=config_entry.data.get("app_key"),
+        app_secret=config_entry.data.get("app_secret"),
+        access_token=config_entry.data.get("access_token"),
+        refresh_token=config_entry.data.get("refresh_token"),
+        house_no=config_entry.data.get("house_no"),
+        app_version=APP_VERSION,
+        client_version=CLIENT_VERSION,
+        client_model=CLIENT_MODEL,
+    )
+
+    # Establish WebSocket connection and set up listeners for device updates.
+    await ws_sync.reconnect()
+    listen_task = hass.loop.create_task(ws_sync.listen())
+    keep_alive_task = hass.loop.create_task(ws_sync.keep_alive())
+    refresh_token_task = hass.loop.create_task(ws_sync.refresh_token())
+    hass.data[DOMAIN][instance_id].setdefault(
+        "ws",
+        {
+            "ws_sync": ws_sync,
+            "listen_task": listen_task,
+            "keep_alive_task": keep_alive_task,
+            "refresh_token_task": refresh_token_task,
+        },
+    )
+
+    # Perform clean-up after successful setup.
+    hass.data[DOMAIN][instance_id].pop("devices", None)
+
+    # Record setup completion and device registry initialization.
+    await persist_messages_with_status_code(
+        hass=hass,
+        status=instance_id,
+        message="Successfully initialized Duwi Smart Hub. Your house's name is: "
+        + config_entry.data.get("house_name"),
+    )
+
+    return True
+
+
+def setup_device_registry(devices):
+    """Organize devices into a structured registry."""
+    device_registry = {}
+    for device in devices:
+        for main_type, type_no_map in type_map.items():
+            if (
+                device.device_type_no in type_no_map
+                and not device.device_type_no.startswith(const.SENSOR_TYPE)
+            ):
+                device_registry.setdefault(main_type, {}).setdefault(
+                    type_no_map[device.device_type_no], []
+                ).append(device)
+
+    return device_registry
+
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Unload a Duwi Smart Hub config entry."""
+
+    # Attempt to unload all platforms associated with the entry.
+    return await hass.config_entries.async_unload_platforms(
+        config_entry, SUPPORTED_PLATFORMS
+    )
+
+
+async def async_remove_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Remove a Duwi Smart Hub config entry and its associated data."""
+
+    house_no = config_entry.data.get("house_no")
+
+    # Remove the house number from the existing houses list, if present.
+    if house_no in hass.data[DOMAIN].get("existing_house", []):
+        hass.data[DOMAIN]["existing_house"].remove(house_no)
+
+    # Close the websocket connection if it exists.
+    # Retrieve instance-specific data from the Home Assistant global data store.
+    entry_data = hass.data[DOMAIN].get(config_entry.entry_id)
+    if entry_data is not None:  # If instance data exists, proceed.
+        ws = entry_data.get("ws")  # Fetch WebSocket details.
+        if ws:
+            ws_sync = ws.get("ws_sync")  # Obtain the synchronous WebSocket object.
+            if ws_sync:
+                try:
+                    await ws_sync.disconnect()  # Attempt to disconnect the WebSocket.
+                    _LOGGER.info(
+                        "WebSocket connection closed."
+                    )  # Log successful disconnect.
+                except (
+                    Exception
+                ) as exc:  # Catch and log any exceptions during disconnect.
+                    _LOGGER.error(f"Error disconnecting WebSocket: {exc}")
+
+            # Define an array of task names that the WebSocket may have started.
+            for task_name in ["listen_task", "keep_alive_task", "refresh_token_task"]:
+                task = ws.get(task_name)  # Retrieve task.
+                if task:  # If task exists, check its state.
+                    if not task.done():  # If task is not finished, cancel it.
+                        task.cancel()
+                        try:
+                            await task  # Wait for task to handle the cancellation.
+                        except asyncio.CancelledError:  # Handle task cancellation.
+                            _LOGGER.debug(
+                                f"{task_name} cancellation completed."
+                            )  # Confirm cancellation.
+                        except (
+                            Exception
+                        ) as exc:  # Catch any exceptions during cancellation.
+                            _LOGGER.error(f"Error in finalising {task_name}: {exc}")
+                    else:
+                        # If the task had already reached completion, log this information.
+                        _LOGGER.debug(f"{task_name} was already completed.")
+
+    # Finally, remove the entry's data from the domain's storage.
+    hass.data[DOMAIN].pop(config_entry.entry_id, None)
+
+    return True

--- a/homeassistant/components/duwi/config_flow.py
+++ b/homeassistant/components/duwi/config_flow.py
@@ -1,0 +1,202 @@
+"""Config flow for Duwi Smart Hub integration."""
+
+import logging
+
+import voluptuous as vol
+from duwi_smarthome_sdk.api.account import AccountClient
+from duwi_smarthome_sdk.api.house import HouseInfoClient
+from duwi_smarthome_sdk.const.status import Code
+
+from homeassistant import config_entries
+
+from .const import DOMAIN, APP_VERSION, CLIENT_MODEL, CLIENT_VERSION
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Configuration class that handles flow initiated by the user for Duwi integration
+class DuwiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    # Use version 1 for the configuration flow
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """
+        Handle a flow initiated by the user.
+
+        This function tries to authenticate using the user-provided credentials (if any),
+        processes the server response, and navigates to the next configuration flow step accordingly.
+        """
+
+        # Placeholder for error messages
+        errors = {}
+
+        # Ensure DOMAIN data has been initialized in Home Assistant
+        self.hass.data.setdefault(DOMAIN, {})
+
+        # Check if user has provided app_key and app_secret
+        if user_input and user_input.get("app_key") and user_input.get("app_secret"):
+
+            # Initialize account client with provided details
+            lc = AccountClient(
+                app_key=user_input["app_key"],
+                app_secret=user_input["app_secret"],
+                app_version=APP_VERSION,
+                client_version=CLIENT_VERSION,
+                client_model=CLIENT_MODEL,
+            )
+
+            # Try to authenticate with given credentials
+            status = await lc.auth(user_input["app_key"], user_input["app_secret"])
+            # Process returned status codes and handle potential errors
+            if status == Code.APP_KEY_ERROR.value:
+                errors["base"] = "auth_error"
+            elif status == Code.SIGN_ERROR.value:
+                errors["base"] = "sign_error"
+            elif status == Code.SYS_ERROR.value:
+                errors["base"] = "sys_error"
+            elif status == Code.SUCCESS.value:
+                # On success, Store credentials in Home Assistant and go to next configuration step
+                self.hass.data[DOMAIN]["app_key"] = user_input["app_key"]
+                self.hass.data[DOMAIN]["app_secret"] = user_input["app_secret"]
+                return await self.async_step_auth()
+            else:
+                # Handle any other unexpected error status
+                errors["base"] = "unknown_error"
+
+        # Show user input form (with error messages if any)
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("app_key"): str,
+                    vol.Required("app_secret"): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_auth(self, user_input=None):
+        """
+        Handle the authentication step in the configuration flow.
+
+        This step authenticates the user with their phone number and password, fetches
+        house information upon successful login, and transitions to house selection.
+        """
+        errors = {}
+        if user_input and user_input.get("phone") and user_input.get("password"):
+
+            # Access the stored app credentials from previous step
+            app_key = self.hass.data[DOMAIN]["app_key"]
+            app_secret = self.hass.data[DOMAIN]["app_secret"]
+            phone = user_input["phone"]
+            password = user_input["password"]
+
+            # Initialize the AccountClient for authentication
+            lc = AccountClient(
+                app_key=app_key,
+                app_secret=app_secret,
+                app_version=APP_VERSION,
+                client_version=CLIENT_VERSION,
+                client_model=CLIENT_MODEL,
+            )
+
+            # Perform the login with provided phone number and password
+            status, auth_token = await lc.login(phone, password)
+
+            # Process the login response and handle accordingly
+            if status == Code.SUCCESS.value:
+                # Initiate HouseInfoClient for house info retrieval
+                hic = HouseInfoClient(
+                    app_key=app_key,
+                    app_secret=app_secret,
+                    access_token=auth_token.access_token,
+                    app_version=APP_VERSION,
+                    client_version=CLIENT_VERSION,
+                    client_model=CLIENT_MODEL,
+                )
+                # Fetch the house information
+                status, house_infos = await hic.fetch_house_info()
+
+                if house_infos:
+                    # Store house information and tokens in Home Assistant for use in further steps
+                    self.hass.data[DOMAIN]["houses"] = house_infos
+                    self.hass.data[DOMAIN]["access_token"] = auth_token.access_token
+                    self.hass.data[DOMAIN]["refresh_token"] = auth_token.refresh_token
+                    # Move to the next configuration step to select a house
+                    return await self.async_step_select_house()
+                else:
+                    # Handle case where no houses are found
+                    errors["base"] = "no_houses_found_error"
+            elif status == Code.LOGIN_ERROR.value:
+                # Handle login error status
+                errors["base"] = "invalid_auth"
+            elif status == Code.SYS_ERROR.value:
+                # Handle system error status
+                errors["base"] = "sys_error"
+            else:
+                # Handle unknown error status
+                errors["base"] = "unknown_error"
+
+        # Show the authentication form with constructed errors
+        return self.async_show_form(
+            step_id="auth",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("phone"): str,
+                    vol.Required("password"): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_select_house(self, user_input=None):
+        """
+        Handle the selection of a house by the user.
+
+        In this step, the function determines the list of houses the user can select from,
+        processes their selection, stores the selected house's details, and creates an entry for it.
+        """
+
+        # Placeholder for error messages.
+        errors = {}
+
+        # Extract houses data from Home Assistant.
+        houses = self.hass.data[DOMAIN]["houses"]
+        # Retrieve the list of pre-existing houses to exclude.
+        existing_house = self.hass.data[DOMAIN].get("existing_house", [])
+
+        # Create a houses list excluding already existing ones.
+        houses_list = {
+            house.house_no: house.house_name
+            for house in houses
+            if house.house_no not in existing_house
+        }
+
+        # If no houses remain, handle the error.
+        if len(houses_list) == 0:
+            errors["base"] = "no_houses_found_error"
+
+        # With user's house selection, create an entry for the selected house.
+        if user_input is not None:
+            return self.async_create_entry(
+                title=houses_list[user_input["house_no"]],
+                data={
+                    "access_token": self.hass.data[DOMAIN]["access_token"],
+                    "refresh_token": self.hass.data[DOMAIN]["refresh_token"],
+                    "house_no": user_input["house_no"],
+                    "house_name": houses_list[user_input["house_no"]],
+                    "app_key": self.hass.data[DOMAIN]["app_key"],
+                    "app_secret": self.hass.data[DOMAIN]["app_secret"],
+                },
+            )
+
+        # If no house has been selected yet, show the selection form.
+        return self.async_show_form(
+            step_id="select_house",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("house_no"): vol.In(houses_list),
+                }
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/duwi/const.py
+++ b/homeassistant/components/duwi/const.py
@@ -1,0 +1,27 @@
+"""Constants for the Duwi integration.
+
+This module contains constants that are used throughout the Duwi Smart Hub integration,
+including configuration keys, default values, and URLs for API endpoints.
+"""
+
+from homeassistant.const import Platform
+
+# Unique domain identifier for the Duwi Smart Hub integration
+DOMAIN = "duwi"
+
+# Manufacturer of the product for identification purposes
+MANUFACTURER = "Duwi"
+
+# Version of the App for the Duwi Smart Hub integration, used for tracking and compatibility.
+APP_VERSION = "0.1.1"
+
+# Home Assistant client version
+CLIENT_VERSION = "0.1.1"
+
+# Model identification of the Home Assistant client, typically used for logging or diagnostics.
+CLIENT_MODEL = "homeassistant"
+
+# List of platforms that support config entry
+SUPPORTED_PLATFORMS = [Platform.COVER, Platform.LIGHT, Platform.SWITCH]
+
+SENSOR_TYPE = "7"

--- a/homeassistant/components/duwi/cover.py
+++ b/homeassistant/components/duwi/cover.py
@@ -1,0 +1,425 @@
+"""Support for Duwi Smart Cover."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from duwi_smarthome_sdk.api.control import ControlClient
+from duwi_smarthome_sdk.const.status import Code
+from duwi_smarthome_sdk.model.req.device_control import ControlDevice
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, CLIENT_MODEL, APP_VERSION, CLIENT_VERSION, MANUFACTURER
+from .util import debounce, persist_messages_with_status_code
+
+_LOGGER = logging.getLogger(__name__)
+
+# Supported types of Duwi Covers
+DUWI_COVER_TYPES = ["Roll", "Shutter"]
+
+# Define supported features for each cover type:
+SUPPORTED_COVER_MODES = {
+    "Roll": (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
+        | CoverEntityFeature.SET_POSITION
+    ),
+    "Shutter": (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
+        | CoverEntityFeature.SET_POSITION
+        | CoverEntityFeature.OPEN_TILT
+        | CoverEntityFeature.STOP_TILT
+        | CoverEntityFeature.CLOSE_TILT
+        | CoverEntityFeature.SET_TILT_POSITION
+    ),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Duwi cover platform based on the configuration entry."""
+
+    # Use the entry_id to access the specific instance information.
+    instance_id = config_entry.entry_id
+
+    # Ensure the relevant domain data is available for this instance.
+    if DOMAIN in hass.data and "house_no" in hass.data[DOMAIN][instance_id]:
+        # Retrieve the devices classified under 'COVER' for the instance.
+        devices = hass.data[DOMAIN][instance_id].get("devices", {}).get("COVER", {})
+
+        # Prepare a list to accumulate entities to add.
+        entities_to_add = []
+
+        if devices:  # Check if devices exist.
+            # Iterate over each cover type defined in DUWI_COVER_TYPES.
+            for cover_type in DUWI_COVER_TYPES:
+                # Check if there are devices for the current cover type.
+                if cover_type in devices:
+                    for device in devices[cover_type]:
+                        # Set common attributes to pass to the entity.
+                        common_attributes = {
+                            "hass": hass,
+                            "instance_id": instance_id,
+                            "unique_id": device.device_no,
+                            "device_name": device.device_name,
+                            "device_no": device.device_no,
+                            "house_no": device.house_no,
+                            "room_name": device.room_name,
+                            "floor_name": device.floor_name,
+                            "terminal_sequence": device.terminal_sequence,
+                            "route_num": device.route_num,
+                            "state": device.value.get("switch", "off") == "on",
+                            "available": device.value.get("online"),
+                            "position": int(device.value.get("control_percent", 0)),
+                            "supported_features": SUPPORTED_COVER_MODES[cover_type],
+                        }
+
+                        # Handle special attributes and features for shutters.
+                        if cover_type == "Shutter":
+                            tilt_position = int(
+                                device.value.get(
+                                    "angle_degree", device.value.get("light_angle", 0)
+                                )
+                            )
+                            # Adjust tilt position if necessary.
+                            if tilt_position > 90:
+                                tilt_position -= 90
+                            # Convert to percentage.
+                            common_attributes["tilt_position"] = (
+                                int(tilt_position / 90 * 100) / 10.0
+                            )
+
+                        # Instantiate the cover entity with common attributes.
+                        new_entity = DuwiCover(**common_attributes)
+                        # Append the new entity to the list of entities to add.
+                        entities_to_add.append(new_entity)
+
+            # Add all prepared entities to Home Assistant.
+            if entities_to_add:
+                async_add_entities(entities_to_add)
+
+
+class DuwiCover(CoverEntity):
+    """A Duwi Cover device. Inherits from Home Assistant's CoverEntity class."""
+
+    # Class variable declarations, setting default values for entity attributes
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        instance_id: str,
+        unique_id: str,
+        device_no: str,
+        terminal_sequence: str,
+        route_num: str,
+        device_name: str,
+        house_no: str,
+        floor_name: str,
+        room_name: str,
+        state: bool,
+        available: bool,
+        position: int | None = None,
+        tilt_position: int | None = None,
+        supported_features: CoverEntityFeature | None = None,
+    ) -> None:
+        """Initialize the DuwiCover entity."""
+
+        # All these are instance variables specific to each unique device
+        self._unique_id = unique_id
+        self._device_no = device_no
+        self._terminal_sequence = terminal_sequence
+        self._route_num = route_num
+        self._device_name = device_name
+        self._house_no = house_no
+        self._floor_name = floor_name
+        self._room_name = room_name
+        self._route_num = route_num
+        self._state = state
+        self._available = available
+        self._position = position
+        self._attr_supported_features = supported_features
+        self._set_position = None
+        self._set_tilt_position = None
+        self._tilt_position = tilt_position
+        self._requested_closing = True
+        self._requested_closing_tilt = True
+        self._unsub_listener_cover = None
+        self._unsub_listener_cover_tilt = None
+        self._is_opening = False
+        self._is_closing = False
+        self._instance_id = instance_id
+
+        # Derive whether Cover is closed or not.
+        self._closed = position is None or position <= 0
+
+        # Construct device_info dictionary
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, unique_id)},
+            manufacturer=MANUFACTURER,
+            name=(self._room_name + " " if self._room_name else "") + device_name,
+            suggested_area=self._floor_name + " " + (self._room_name or "default room"),
+        )
+
+        # Create ControlClient & ControlDevice instances
+        self.hass = hass
+        # Extract details from global data for this instance
+        self.cc = ControlClient(
+            app_key=hass.data[DOMAIN][instance_id]["app_key"],
+            app_secret=hass.data[DOMAIN][instance_id]["app_secret"],
+            access_token=hass.data[DOMAIN][instance_id]["access_token"],
+            app_version=APP_VERSION,
+            client_version=CLIENT_VERSION,
+            client_model=CLIENT_MODEL,
+        )
+
+        self.cd = ControlDevice(device_no=self._device_no, house_no=self._house_no)
+
+        # Setting the entity's unique ID based on the device number.
+        self.entity_id = f"cover.duwi_{device_no}"
+
+        # Storing the device number and the method to update the device state
+        # in the Home Assistant's global data store for this particular instance.
+        self.hass.data[DOMAIN][self._instance_id][self.unique_id] = {
+            "device_no": self._device_no,
+            "update_device_state": self.update_device_state,
+        }
+
+        # Initialize a dictionary for this terminal sequence if it doesn't already exist.
+        if self.hass.data[DOMAIN][instance_id].get(self._terminal_sequence) is None:
+            self.hass.data[DOMAIN][instance_id][self._terminal_sequence] = {}
+
+        # Registering the method to update the device state in the global data
+        # store under its terminal sequence and device number.
+        self.hass.data[DOMAIN][instance_id].setdefault("slave", {}).setdefault(
+            self._terminal_sequence, {}
+        )[self._device_no] = self.update_device_state
+
+    @property
+    def unique_id(self) -> str:
+        """Return unique ID for cover."""
+        return self._unique_id
+
+    @property
+    def available(self) -> bool:
+        """Return availability."""
+        return self._available
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Return the current position of the cover."""
+        return self._position
+
+    @property
+    def current_cover_tilt_position(self) -> int | None:
+        """Return the current tilt position of the cover."""
+        return self._tilt_position
+
+    @property
+    def is_closed(self) -> bool:
+        """Return if the cover is closed."""
+        return self._closed
+
+    @property
+    def is_closing(self) -> bool:
+        """Return if the cover is closing."""
+        return self._is_closing
+
+    @property
+    def is_opening(self) -> bool:
+        """Return if the cover is opening."""
+        return self._is_opening
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close the cover completely."""
+        # Set the position to 0 indicating closed cover.
+        self._position = 0
+        # Update the cover control parameters.
+        self.cd.add_param_info("control_percent", int(self._position))
+        # If the action is not scheduled, send control command.
+        if not kwargs.get("is_scheduled", False):
+            status = await self.cc.control(self.cd)
+            # If the control action is successful, update the HA state.
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                # If not successful, log the status code.
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            # If action is scheduled, write the state with debounce.
+            await self.async_write_ha_state_with_debounce()
+        # Clear the parameter information after the action is complete.
+        self.cd.remove_param_info()
+
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+        """Close the tilt of the cover."""
+        # Set the tilt position to 0 indicating closed tilt.
+        self._tilt_position = 0
+        # Update the cover tilt parameters.
+        self.cd.add_param_info("angle_degree", int(self._position))
+        self.cd.add_param_info("light_angle", int(self._position))
+        # Similar control mechanism as in async_close_cover.
+        if not kwargs.get("is_scheduled", False):
+            status = await self.cc.control(self.cd)
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            await self.async_write_ha_state_with_debounce()
+        self.cd.remove_param_info()
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open the cover completely."""
+        # Set the position to 100 indicating fully open cover.
+        self._position = 100
+        # Update the cover control parameters.
+        self.cd.add_param_info("control_percent", int(self._position))
+        # Similar control mechanism as in async_close_cover.
+        if not kwargs.get("is_scheduled", False):
+            status = await self.cc.control(self.cd)
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            await self.async_write_ha_state_with_debounce()
+        self.cd.remove_param_info()
+
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+        """Open the tilt of the cover."""
+        # Set the tilt position to 100 indicating fully open tilt.
+        self._tilt_position = 100
+        # Calculate and update the tilt angles.
+        self.cd.add_param_info("angle_degree", int(self._tilt_position / 100 * 90))
+        self.cd.add_param_info("light_angle", int(self._tilt_position / 100 * 90))
+        # Similar control mechanism as in async_close_cover.
+        if not kwargs.get("is_scheduled", False):
+            status = await self.cc.control(self.cd)
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            await self.async_write_ha_state_with_debounce()
+        self.cd.remove_param_info()
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Move the cover to a specific position."""
+        # Get the target position from the service call.
+        position: int = kwargs[ATTR_POSITION]
+        # Store the position internally.
+        self._position = position
+        # Send the position parameter to the device.
+        self.cd.add_param_info("control_percent", int(self._position))
+        # Direct control or state update based on scheduled flag.
+        if not kwargs.get("is_scheduled", False):
+            # Attempt to send the control command to the cover.
+            status = await self.cc.control(self.cd)
+            # On success, update the HA state, otherwise log issue.
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            # If the action is scheduled, debounced state update is used.
+            await self.async_write_ha_state_with_debounce()
+        # Update the internal closed state of the cover based on position.
+        self._closed = (
+            self.current_cover_position is not None and self.current_cover_position <= 0
+        )
+        # Clear params after operation.
+        self.cd.remove_param_info()
+
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+        """Move the cover tilt to a specific position."""
+        # Retrieve and store the desired tilt position.
+        tilt_position: int = kwargs[ATTR_TILT_POSITION]
+        self._tilt_position = tilt_position
+        # Calculate and send the angle to the device.
+        self.cd.add_param_info("angle_degree", int(self._tilt_position / 100 * 90))
+        self.cd.add_param_info("light_angle", int(self._tilt_position / 100 * 90))
+        # Direct control or state update based on scheduled flag.
+        if not kwargs.get("is_scheduled", False):
+            # Send the tilt control command and handle the response.
+            status = await self.cc.control(self.cd)
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            await self.async_write_ha_state_with_debounce()
+        # Clear params after operation.
+        self.cd.remove_param_info()
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the cover from moving."""
+        # Add a stop control command parameter.
+        self.cd.add_param_info("control", "stop")
+        # Send control command or state update based on scheduled action.
+        if not kwargs.get("is_scheduled", False):
+            # Issue the stop command to the device.
+            status = await self.cc.control(self.cd)
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            await self.async_write_ha_state_with_debounce()
+        # Clear params after operation.
+        self.cd.remove_param_info()
+
+    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+        """Stop the movement of the cover's tilt."""
+        # This follows the same logic as the stop cover method.
+        self.cd.add_param_info("control", "stop")
+        if not kwargs.get("is_scheduled", False):
+            status = await self.cc.control(self.cd)
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            await self.async_write_ha_state_with_debounce()
+        self.cd.remove_param_info()
+
+    async def update_device_state(
+        self, action: str = None, is_scheduled: bool = True, **kwargs: Any
+    ):
+        """Update the device state based on the given action."""
+        # A dispatch method for various actions.
+        kwargs["is_scheduled"] = is_scheduled
+        if action == "set_cover_position":
+            await self.async_set_cover_position(**kwargs)
+        elif action == "set_cover_tilt_position":
+            await self.async_set_cover_tilt_position(**kwargs)
+        else:
+            # General state update handling.
+            if "available" in kwargs:
+                self._available = kwargs["available"]
+                self.async_write_ha_state()
+
+    @debounce(0.5)
+    async def async_write_ha_state_with_debounce(self):
+        """Update the HA state with a delay to prevent spamming."""
+        # This method is a throttled version of the immediate state update.
+        self.async_write_ha_state()

--- a/homeassistant/components/duwi/light.py
+++ b/homeassistant/components/duwi/light.py
@@ -1,0 +1,489 @@
+"""Support for Duwi Smart Light."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from duwi_smarthome_sdk.api.control import ControlClient
+from duwi_smarthome_sdk.const.status import Code
+from duwi_smarthome_sdk.model.req.device_control import ControlDevice
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP,
+    ATTR_EFFECT,
+    ATTR_HS_COLOR,
+    ColorMode,
+    LightEntity,
+    LightEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import APP_VERSION, CLIENT_MODEL, CLIENT_VERSION, DOMAIN, MANUFACTURER
+from .util import debounce, persist_messages_with_status_code
+
+# Initialize logger
+_LOGGER = logging.getLogger(__name__)
+# Define the light types supported by this integration
+DUWI_LIGHT_TYPES = ["On", "Dim", "Temp", "DimTemp", "RGB", "RGBW", "RGBCW"]
+# Define the color modes supported by various light types.
+SUPPORTED_COLOR_MODES = {
+    "On": [ColorMode.ONOFF],
+    "Dim": [ColorMode.BRIGHTNESS],
+    "Temp": [ColorMode.COLOR_TEMP],
+    "DimTemp": [ColorMode.COLOR_TEMP],
+    "RGB": [ColorMode.HS],
+    "RGBW": [ColorMode.HS],
+    "RGBCW": [ColorMode.HS],
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Asynchronously set up Duwi devices as Home Assistant entities based on a configuration entry."""
+
+    # Extract the instance id from the provided config entry.
+    instance_id = config_entry.entry_id
+
+    # Access house-specific information if available.
+    if DOMAIN in hass.data and "house_no" in hass.data[DOMAIN][instance_id]:
+        devices = hass.data[DOMAIN][instance_id]["devices"].get("LIGHT")
+
+        # Proceed if there are light devices available.
+        if devices is not None:
+            for device_type in DUWI_LIGHT_TYPES:
+                # Check if current device type is available in the devices dictionary.
+                if device_type in devices:
+                    for device in devices[device_type]:
+                        # Create and adjust the device's effect list.
+                        effect_list = device.value.get("effectList", {})
+                        effect_list_keys = list(effect_list.keys())
+                        effect_list_keys.insert(0, "None")
+                        device_effect_list = effect_list_keys if effect_list else None
+
+                        # Compile common attributes for each device entity.
+                        common_attributes = {
+                            "hass": hass,
+                            "instance_id": instance_id,
+                            "unique_id": device.device_no,
+                            "device_name": device.device_name,
+                            "device_no": device.device_no,
+                            "house_no": device.house_no,
+                            "room_name": device.room_name,
+                            "floor_name": device.floor_name,
+                            "terminal_sequence": device.terminal_sequence,
+                            "route_num": device.route_num,
+                            "light_type": device_type,
+                            "effect_list": device_effect_list,
+                            "effect_map": device.value.get("effectList", None),
+                            "state": device.value.get("switch", "off") == "on",
+                            "available": device.value.get("online", False),
+                            "supported_color_modes": SUPPORTED_COLOR_MODES[device_type],
+                        }
+
+                        # Append device-specific attributes according to its type.
+                        if device_type in ["Dim", "DimTemp"]:
+                            common_attributes["brightness"] = int(
+                                device.value.get("light", 0) / 100 * 255
+                            )
+
+                        if device_type in ["Temp", "DimTemp", "RGBCW"]:
+                            color_temp_range = device.value.get(
+                                "color_temp_range", {"min": 3000, "max": 6000}
+                            )
+                            min_ct, max_ct = color_temp_range.get(
+                                "min", 3000
+                            ), color_temp_range.get("max", 6000)
+                            common_attributes["color_temp_range"] = [min_ct, max_ct]
+                            common_attributes["ct"] = calculate_color_temperature(
+                                device, min_ct, max_ct
+                            )
+
+                        if device_type in ["RGB", "RGBW", "RGBCW"]:
+                            hs_color = extract_hs_color(device)
+                            common_attributes["hs_color"] = hs_color
+                            common_attributes["brightness"] = extract_brightness(device)
+                            common_attributes["is_color_light"] = True
+
+                        # Add the device as a new entity in Home Assistant.
+                        async_add_entities([DuwiLight(**common_attributes)])
+
+
+def calculate_color_temperature(device, min_ct, max_ct):
+    """Calculate and return the color temperature value."""
+    # Insert logic for color temperature calculation here.
+    return (
+        (
+            (500 - 153)
+            * ((max_ct - int(device.value.get("color_temp", 0))) / (max_ct - min_ct))
+            + 153
+        )
+        if device.value.get("color_temp")
+        else 0
+    )
+
+
+def extract_hs_color(device):
+    """Extract and return the HS color."""
+    color_info = device.value.get("color", {"h": 0, "s": 0, "v": 0})
+    return color_info["h"], color_info["s"]
+
+
+def extract_brightness(device):
+    """Extract and return the brightness."""
+    color_info = device.value.get("color", {"h": 0, "s": 0, "v": 0})
+    return int(color_info.get("v", 0) / 100 * 255)
+
+
+class DuwiLight(LightEntity):
+    """Initialize the DuwiLight entity."""
+
+    _attr_has_entity_name = True
+    _attr_name = None
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        instance_id: str,
+        unique_id: str,
+        device_name: str,
+        device_no: str,
+        house_no: str,
+        floor_name: str,
+        room_name: str,
+        light_type: str,
+        terminal_sequence: str,
+        route_num: str,
+        state: bool,
+        is_color_light: bool = False,
+        available: bool = False,
+        brightness: int | None = None,
+        ct: int | None = None,
+        color_temp_range: list[int] | None = None,
+        effect_list: list[str] | None = None,
+        effect_map: dict[str, str] | None = None,
+        effect: str | None = None,
+        hs_color: tuple[int, int] | None = None,
+        rgb_color: tuple[int, int] | None = None,
+        rgbw_color: tuple[int, int, int, int] | None = None,
+        rgbww_color: tuple[int, int, int, int, int] | None = None,
+        supported_color_modes: set[ColorMode] | None = None,
+    ) -> None:
+        """Initialize the light."""
+        self._device_no = device_no
+        self._terminal_sequence = terminal_sequence
+        self._route_num = route_num
+        self._is_color_light = is_color_light
+        self._house_no = house_no
+        self._type = light_type
+        self._color_temp_range = color_temp_range
+        self._floor_name = floor_name
+        self._room_name = room_name
+
+        self._instance_id = instance_id
+        self._available = available
+        self._brightness = brightness
+        self._ct = ct
+        self._effect = effect
+        self._effect_list = effect_list
+        self._effect_map = effect_map
+        self._hs_color = hs_color
+        self._rgbw_color = rgbw_color
+        self._rgbww_color = rgbww_color
+        self._state = state
+        self._unique_id = unique_id
+        if hs_color:
+            self._color_mode = ColorMode.HS
+        elif rgb_color:
+            self._color_mode = ColorMode.RGB
+        elif rgbw_color:
+            self._color_mode = ColorMode.RGBW
+        elif rgbww_color:
+            self._color_mode = ColorMode.RGBWW
+        elif ct:
+            self._color_mode = ColorMode.COLOR_TEMP
+        elif brightness:
+            self._color_mode = ColorMode.BRIGHTNESS
+        else:
+            self._color_mode = ColorMode.ONOFF
+        self._supported_color_modes = supported_color_modes
+        self._color_modes = supported_color_modes
+        if self._effect_list is not None:
+            self._attr_supported_features |= LightEntityFeature.EFFECT
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, unique_id)},
+            manufacturer=MANUFACTURER,
+            name=(
+                self._room_name + " "
+                if self._room_name is not None and self._room_name != ""
+                else ""
+            )
+            + device_name,
+            suggested_area=(
+                self._floor_name + " " + self._room_name
+                if self._room_name is not None and self._room_name != ""
+                else "default room"
+            ),
+        )
+        self.hass = hass
+        self.cc = ControlClient(
+            app_key=self.hass.data[DOMAIN][instance_id]["app_key"],
+            app_secret=self.hass.data[DOMAIN][instance_id]["app_secret"],
+            access_token=self.hass.data[DOMAIN][instance_id]["access_token"],
+            app_version=APP_VERSION,
+            client_version=CLIENT_VERSION,
+            client_model=CLIENT_MODEL,
+        )
+        self.cd = ControlDevice(
+            device_no=self._device_no,
+            house_no=self._house_no,
+        )
+        # 存入全局的实体id
+        self.entity_id = f"light.duwi_{device_no}"
+        self.hass.data[DOMAIN][instance_id][unique_id] = {
+            "device_no": self._device_no,
+            "color_temp_range": self._color_temp_range,
+            "update_device_state": self.update_device_state,
+        }
+
+        if self.hass.data[DOMAIN][instance_id].get(self._terminal_sequence) is None:
+            self.hass.data[DOMAIN][instance_id][self._terminal_sequence] = {}
+        self.hass.data[DOMAIN][instance_id].setdefault("slave", {}).setdefault(
+            self._terminal_sequence, {}
+        )[self._device_no] = self.update_device_state
+
+    @property
+    def unique_id(self) -> str:
+        """Return unique ID for light."""
+        return self._unique_id
+
+    @property
+    def available(self) -> bool:
+        """Return availability."""
+        return self._available
+
+    @property
+    def brightness(self) -> int:
+        """Return the brightness of this light between 0..255."""
+        return self._brightness
+
+    @property
+    def color_mode(self) -> str | None:
+        """Return the color mode of the light."""
+        return self._color_mode
+
+    @property
+    def hs_color(self) -> tuple[int, int] | None:
+        """Return the hs color value."""
+        return self._hs_color
+
+    @property
+    def rgbw_color(self) -> tuple[int, int, int, int] | None:
+        """Return the rgbw color value."""
+        return self._rgbw_color
+
+    @property
+    def rgbww_color(self) -> tuple[int, int, int, int, int] | None:
+        """Return the rgbww color value."""
+        return self._rgbww_color
+
+    @property
+    def color_temp(self) -> int:
+        """Return the CT color temperature."""
+        return self._ct
+
+    @property
+    def effect_list(self) -> list[str] | None:
+        """Return the list of supported effects."""
+        return self._effect_list
+
+    @property
+    def effect(self) -> str | None:
+        """Return the current effect."""
+        return self._effect
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if light is on."""
+        return self._state
+
+    @property
+    def supported_color_modes(self) -> set[ColorMode]:
+        """Flag supported color modes."""
+        return self._color_modes
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        self._state = True
+        self._effect = "None"
+        if ATTR_BRIGHTNESS in kwargs:
+            # Set brightness from kwargs if present
+            self._brightness = kwargs[ATTR_BRIGHTNESS]
+            if self._is_color_light:
+                # If it's a color light, adjust the color brightness accordingly
+                self.cd.add_param_info(
+                    "color",
+                    {
+                        "h": self.hs_color[0],
+                        "s": self.hs_color[1],
+                        "v": int(round(self._brightness / 255 * 100)),
+                    },
+                )
+            else:
+                # If it's not a color light, just set the light brightness
+                self.cd.add_param_info(
+                    "light", int(round(self._brightness / 255 * 100))
+                )
+
+        if ATTR_COLOR_TEMP in kwargs:
+            # Handle setting of color temperature
+            self._color_mode = ColorMode.COLOR_TEMP
+            self._ct = kwargs[ATTR_COLOR_TEMP]
+            # Perform appropriate conversion to device's color temperature
+            self.cd.add_param_info(
+                "color_temp",
+                int(
+                    (
+                        self._color_temp_range[1]
+                        - int(
+                            (
+                                (self._ct - 153)
+                                * (
+                                    self._color_temp_range[1]
+                                    - self._color_temp_range[0]
+                                )
+                                / (500 - 153)
+                            )
+                        )
+                    )
+                    // 100.0
+                    * 100
+                ),
+            )
+
+        if ATTR_EFFECT in kwargs:
+            # Set effect based on the chosen effect name
+            self._effect = kwargs[ATTR_EFFECT]
+            if self._effect != "None":
+                effect_data = json.loads(self._effect_map[self._effect])
+                if "light" in effect_data:
+                    # Adjust brightness based on effect data
+                    self._brightness = int(round(effect_data["light"] / 100 * 255))
+                    self.cd.add_param_info("light", effect_data["light"])
+                if "color_temp" in effect_data:
+                    # Adjust color temperature based on effect data
+                    self._ct = self.convert_to_ha_color_temp(effect_data["color_temp"])
+                    self.cd.add_param_info("color_temp", effect_data["color_temp"])
+                if "color" in effect_data:
+                    # Adjust HS color based on effect data
+                    self._hs_color = (
+                        effect_data["color"]["h"],
+                        effect_data["color"]["s"],
+                    )
+                    self._brightness = int(round(effect_data["color"]["v"] / 100 * 255))
+                    self.cd.add_param_info("color", effect_data["color"])
+
+        if ATTR_HS_COLOR in kwargs:
+            # Directly set HS color from arguments
+            self._color_mode = ColorMode.HS
+            self._hs_color = kwargs[ATTR_HS_COLOR]
+            self.cd.add_param_info(
+                "color",
+                {
+                    "h": self._hs_color[0],
+                    "s": self._hs_color[1],
+                    "v": int(round(self._brightness / 255 * 100)),
+                },
+            )
+
+        if not kwargs.get("is_scheduled", False):
+            # Inform Home Assistant to update state
+            if len(self.cd.commands) == 0:
+                self.cd.add_param_info("switch", "on")
+            status = await self.cc.control(self.cd)
+            # If the request was successful, update the state
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            await self.async_write_ha_state_with_debounce()
+
+        self.cd.remove_param_info()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
+        self._state = False
+
+        # Update Home Assistant about the new state after disabling polling
+        self.cd.add_param_info("switch", "off")
+
+        if not kwargs.get("is_scheduled", False):
+            status = await self.cc.control(self.cd)
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            await self.async_write_ha_state_with_debounce()
+        self.cd.remove_param_info()
+
+    async def async_toggle(self, **kwargs: Any) -> None:
+        """Toggle the light's current state."""
+        if self._state:
+            await self.async_turn_off(**kwargs)
+        else:
+            await self.async_turn_on(**kwargs)
+
+    async def update_device_state(
+        self, action: str = None, is_scheduled: bool = True, **kwargs: Any
+    ):
+        """Update the device state."""
+        kwargs["is_scheduled"] = is_scheduled
+        if action == "turn_on":
+            await self.async_turn_on(**kwargs)
+        elif action == "turn_off":
+            await self.async_turn_off(**kwargs)
+        elif action == "toggle":
+            await self.async_toggle(**kwargs)
+        else:
+            if "available" in kwargs:
+                self._available = kwargs["available"]
+                self.async_write_ha_state()
+
+    def convert_to_ha_color_temp(self, duwi_ct):
+        """Convert device-specific color temperature to HA color temperature."""
+        if not self._color_temp_range:
+            self._color_temp_range = [3000, 6000]
+        return (
+            (
+                (500 - 153)
+                * (
+                    (self._color_temp_range[1] - duwi_ct)
+                    / (self._color_temp_range[1] - self._color_temp_range[0])
+                )
+                + 153
+            )
+            if duwi_ct
+            else 0
+        )
+
+    # def convert_to_ha_color_temp(self, duwi_ct):
+    #     """Convert device-specific color temperature to HA color temperature."""
+    #     if not self._color_temp_range:
+    #         self._color_temp_range = [3000, 6000]
+    #     return ((500 - 153) * ((self._color_temp_range[1] - duwi_ct) / (
+    #             self._color_temp_range[1] - self._color_temp_range[0])) + 153) if duwi_ct else 0
+
+    @debounce(0.5)
+    async def async_write_ha_state_with_debounce(self):
+        self.async_write_ha_state()

--- a/homeassistant/components/duwi/manifest.json
+++ b/homeassistant/components/duwi/manifest.json
@@ -1,0 +1,14 @@
+{
+  "domain": "duwi",
+  "name": "Duwi",
+  "codeowners": [
+    "@duwi"
+  ],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/duwi",
+  "iot_class": "cloud_push",
+  "loggers": ["duwi"],
+  "issue_tracker": "https://github.com/home-assistant/core/issues",
+  "requirements": ["websockets","duwi_smarthome_sdk==0.1.4"],
+  "version": "0.1.0"
+}

--- a/homeassistant/components/duwi/switch.py
+++ b/homeassistant/components/duwi/switch.py
@@ -1,0 +1,209 @@
+"""Support for Duwi Smart Switch."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from duwi_smarthome_sdk.api.control import ControlClient
+from duwi_smarthome_sdk.const.status import Code
+from duwi_smarthome_sdk.model.req.device_control import ControlDevice
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import APP_VERSION, CLIENT_MODEL, CLIENT_VERSION, DOMAIN, MANUFACTURER
+from .util import debounce, persist_messages_with_status_code
+
+# Initialize logger
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    # Retrieve the instance ID from the configuration entry
+    instance_id = config_entry.entry_id
+
+    # Check if the DUWI_DOMAIN is loaded and has house_no available
+    if DOMAIN in hass.data and "house_no" in hass.data[DOMAIN][instance_id]:
+        # Access the SWITCH devices from the domain storage
+        devices = hass.data[DOMAIN][instance_id]["devices"].get("SWITCH")
+
+        # If there are devices present, proceed with entity addition
+        if devices is not None:
+            # Helper function to create DuwiSwitch entities
+            def create_switch_entities(device_list):
+                return [
+                    DuwiSwitch(
+                        hass=hass,
+                        instance_id=instance_id,
+                        unique_id=device.device_no,
+                        device_name=device.device_name,
+                        device_no=device.device_no,
+                        house_no=device.house_no,
+                        room_name=device.room_name,
+                        floor_name=device.floor_name,
+                        terminal_sequence=device.terminal_sequence,
+                        route_num=device.route_num,
+                        state=device.value.get("switch", None) == "on",
+                        available=device.value.get("online", False),
+                    )
+                    for device in device_list
+                ]
+
+            # Loop through each switch type ['On', 'Off', other types if exist] to create entities
+            for switch_type in devices.keys():
+                switch_entities = create_switch_entities(devices[switch_type])
+                async_add_entities(switch_entities)
+
+
+class DuwiSwitch(SwitchEntity):
+    """Initialize the DuwiSwitch entity."""
+
+    _attr_name = None
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        instance_id: str,
+        device_no: str,
+        unique_id: str,
+        terminal_sequence: str,
+        route_num: str,
+        house_no: str,
+        room_name: str,
+        floor_name: str,
+        state: bool,
+        available: bool,
+        device_name: str,
+        assumed: bool = False,
+    ) -> None:
+        """Initialize the Duwi Switch Entity."""
+        self._device_no = device_no
+        self._unique_id = unique_id
+        self._terminal_sequence = terminal_sequence
+        self._route_num = route_num
+        self._house_no = house_no
+        self._room_name = room_name
+        self._floor_name = floor_name
+
+        self._instance_id = instance_id
+        self._is_on = state
+        self._available = available
+        self._assumed = assumed
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, unique_id)},
+            manufacturer=MANUFACTURER,
+            name=(
+                self._room_name + " "
+                if self._room_name is not None and self._room_name != ""
+                else ""
+            )
+            + device_name,
+            suggested_area=(
+                self._floor_name + " " + self._room_name
+                if self._room_name is not None and self._room_name != ""
+                else "default room"
+            ),
+        )
+
+        self.hass = hass
+
+        # Initialize Control Client
+        self.cc = ControlClient(
+            app_key=self.hass.data[DOMAIN][instance_id]["app_key"],
+            app_secret=self.hass.data[DOMAIN][instance_id]["app_secret"],
+            access_token=self.hass.data[DOMAIN][instance_id]["access_token"],
+            app_version=APP_VERSION,
+            client_version=CLIENT_VERSION,
+            client_model=CLIENT_MODEL,
+        )
+
+        # Initialize Control Device
+        self.cd = ControlDevice(device_no=self._device_no, house_no=self._house_no)
+
+        # Store unique entity ID globally
+        self.entity_id = f"switch.duwi_{device_no}"
+        self.hass.data[DOMAIN][instance_id][unique_id] = {
+            "device_no": self._device_no,
+            "update_device_state": self.update_device_state,
+        }
+        if self.hass.data[DOMAIN][instance_id].get(self._terminal_sequence) is None:
+            self.hass.data[DOMAIN][instance_id][self._terminal_sequence] = {}
+        self.hass.data[DOMAIN][instance_id].setdefault("slave", {}).setdefault(
+            self._terminal_sequence, {}
+        )[self._device_no] = self.update_device_state
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID of the entity."""
+        return self._unique_id
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the switch is on."""
+        return self._is_on
+
+    @property
+    def available(self) -> bool:
+        """Return the device's availability."""
+        return self._available
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the switch on."""
+        self._is_on = True
+        # Update HA State to 'on'
+        self.cd.add_param_info("switch", "on")
+        if not kwargs.get("is_scheduled", False):
+            status = await self.cc.control(self.cd)
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            await self.async_write_ha_state_with_debounce()
+        self.cd.remove_param_info()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the switch off."""
+        self._is_on = False
+        # Update HA State to 'off'
+        self.cd.add_param_info("switch", "off")
+        # Control the switch only if the action is not locked.
+        if not kwargs.get("is_scheduled", False):
+            status = await self.cc.control(self.cd)
+            if status == Code.SUCCESS.value:
+                self.async_write_ha_state()
+            else:
+                await persist_messages_with_status_code(hass=self.hass, status=status)
+        else:
+            await self.async_write_ha_state_with_debounce()
+        self.cd.remove_param_info()
+
+    async def update_device_state(
+        self, action: str = None, is_scheduled: bool = True, **kwargs: Any
+    ):
+        """Update the device state."""
+        kwargs["is_scheduled"] = is_scheduled
+        if action == "turn_on":
+            await self.async_turn_on(**kwargs)
+        elif action == "turn_off":
+            await self.async_turn_off(**kwargs)
+        elif action == "toggle":
+            await self.async_toggle(**kwargs)
+        else:
+            if "available" in kwargs:
+                self._available = kwargs["available"]
+                self.async_write_ha_state()
+
+    @debounce(0.5)
+    async def async_write_ha_state_with_debounce(self):
+        self.async_write_ha_state()

--- a/homeassistant/components/duwi/util.py
+++ b/homeassistant/components/duwi/util.py
@@ -1,0 +1,242 @@
+"""Utility methods for the Duwi Smart Hub integration"""
+
+import asyncio
+import json
+import logging
+from typing import Callable, Optional
+
+from duwi_smarthome_sdk.const.status import Code
+
+from homeassistant.components.persistent_notification import (
+    async_create as async_create_notification,
+)
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def trans_duwi_state_to_ha_state(
+    hass: HomeAssistant, instance_id: str, message: str
+):
+    """
+    Synchronize the entity's state in Home Assistant based on the received message.
+
+    This asynchronous function analyzes the incoming message from the Duwi device and updates
+    the matching entities in Home Assistant accordingly.
+
+    Args:
+        hass: The instance of Home Assistant core.
+        instance_id: A unique identifier associated with the Duwi device instance.
+        message: The received message containing state information to be parsed and synchronized.
+
+    Note:
+        - The function ignores KEEPALIVE messages which don't carry state information.
+        - It processes only certain namespaces that convey meaningful state changes.
+    """
+    _LOGGER.debug(f"Received message---------------: {message}")
+    # Ignore KEEPALIVE messages as they do not contain state information.
+    if message == "KEEPALIVE":
+        _LOGGER.debug("Received KEEPALIVE message.")
+        return
+
+    # Attempting to parse the JSON message.
+    try:
+        message_data = json.loads(message)
+    except json.JSONDecodeError:
+        _LOGGER.error("Failed to parse message - Not a valid JSON string.")
+        return
+
+    namespace = message_data.get("namespace")
+
+    # Proceed only with the expected namespaces.
+    if namespace not in ["Duwi.RPS.DeviceValue", "Duwi.RPS.TerminalOnline"]:
+        _LOGGER.debug(f"Received message with unexpected namespace: {namespace}")
+        return
+
+    # Checking for a result within the message.
+    result = message_data.get("result")
+    if not result:
+        _LOGGER.debug("Received message with no result.")
+        return
+
+    # Parsing the result if it's a string.
+    if isinstance(result, str):
+        try:
+            result = json.loads(result)
+        except json.JSONDecodeError:
+            _LOGGER.error("Parsing error - result is not a valid JSON string.")
+            return
+
+    msg = result.get("msg")
+    if not msg:
+        _LOGGER.debug("Received message with no msg detail.")
+        return
+
+    # Handling TerminalOnline namespace separately.
+    if namespace == "Duwi.RPS.TerminalOnline":
+        sequence = msg.get("sequence")
+        is_online = msg.get("online")
+        _LOGGER.debug(f"Duwi.RPS.TerminalOnline {sequence} is online: {is_online}")
+
+        device_updates = (
+            hass.data[DOMAIN][instance_id].get("slave", {}).get(sequence, None)
+        )
+        if device_updates and (
+            hass.data[DOMAIN][instance_id]
+            .get("slave", {})
+            .get(sequence, {})
+            .get("is_follow_online")
+            or not is_online
+        ):
+            # Sequence type is slave machine
+            _LOGGER.debug(
+                f"Slave update device online status: {hass.data[DOMAIN][instance_id].get('slave', {}).get(sequence, None)}"
+            )
+            for device_no, handler in device_updates.items():
+                if callable(handler):
+                    await handler(available=is_online)
+            return
+
+        terminals = hass.data[DOMAIN][instance_id].get("host", {}).get(sequence)
+        if terminals and not is_online:
+            # Sequence type is host engine
+            _LOGGER.debug(
+                f"host update device offline: {hass.data[DOMAIN][instance_id].get('slave', {}).get(sequence, None)}"
+            )
+            for terminal in terminals:
+                device_updates = (
+                    hass.data[DOMAIN][instance_id].get("slave", {}).get(terminal)
+                )
+
+                if device_updates is not None:
+                    for device_no, handler in device_updates.items():
+                        if callable(handler):
+                            await handler(available=is_online)
+        return
+
+    # Extract device number and retrieve entity ID from Home Assistant data.
+    device_no = msg.get("deviceNo")
+    if not device_no:
+        _LOGGER.debug("Received message with no device_no")
+        return
+
+    if device_no not in hass.data[DOMAIN][instance_id]:
+        _LOGGER.debug(f"Received message with unknown device_no: {device_no}")
+        return
+
+    # Prepare the action and attributes based on the message.
+    action = "turn_on" if msg.get("switch") != "off" else "turn_off"
+
+    attr_dict = {}
+
+    _LOGGER.debug(f"Received message: {msg}")
+    # Process light-specific attributes.
+    if msg.get("online") is not None:
+        action = None
+        attr_dict["available"] = msg.get("online")
+
+    if msg.get("light") is not None:
+        attr_dict["brightness"] = int(round(msg.get("light") / 100 * 255))
+
+    if msg.get("color_temp") is not None:
+        color_temp_range = (
+            hass.data[DOMAIN][instance_id].get(device_no, {}).get("color_temp_range")
+        )
+        ct = 500 - (int(round(msg.get("color_temp"))) - color_temp_range[0]) * (
+            500 - 153
+        ) / (color_temp_range[1] - color_temp_range[0])
+        attr_dict["color_temp"] = int(ct)
+
+    if msg.get("color") is not None:
+        color_info = msg.get("color")
+        hs_color = (color_info["h"], color_info["s"])
+        brightness = int((color_info["v"] / 100) * 255)
+        if brightness == 0:
+            action = "turn_off"
+        attr_dict["brightness"] = brightness
+        attr_dict["hs_color"] = hs_color
+
+    # Process cover-specific attributes.
+    if msg.get("control_percent") is not None:
+        action = "set_cover_position"
+        attr_dict["position"] = msg.get("control_percent")
+
+    if msg.get("light_angle") is not None or msg.get("angle_degree") is not None:
+        action = "set_cover_tilt_position"
+        angle = msg.get("light_angle", msg.get("angle_degree"))
+        attr_dict["tilt_position"] = (180 - angle if angle > 90 else angle) / 90 * 100
+
+    device = hass.data[DOMAIN][instance_id][device_no]
+
+    _LOGGER.debug(
+        f"Received message action: {action}, attributes: {attr_dict}, device: {device}"
+    )
+    await device.get("update_device_state")(
+        action=action, is_scheduled=True, **attr_dict
+    )
+
+
+async def persist_messages_with_status_code(
+    hass: HomeAssistant, status: Optional[str] = None, message: Optional[str] = None
+) -> None:
+    """Persists messages with specific status code.
+
+    Args:
+        hass (HomeAssistant): Instance of Home Assistant.
+        status (str, optional): Status code. Defaults to None.
+        message (str, optional): Message to be persisted. Defaults to None.
+    """
+    messages = {
+        Code.SUCCESS.value: "Success",
+        Code.SYS_ERROR.value: "System Error",
+        Code.LOGIN_ERROR.value: "Login Error",
+        Code.APP_KEY_ERROR.value: "App Key Error",
+        Code.TIMESTAMP_TIMEOUT.value: "Timestamp Timeout",
+        Code.SYSTEM_RATE_LIMIT.value: "System Rate Limit",
+        Code.SYSTEM_MINUTE_RATE_LIMIT.value: "System Minute Rate Limit",
+        Code.SYSTEM_HOUR_RATE_LIMIT.value: "System Hour Rate Limit",
+        Code.GATEWAY_SYS_ERROR.value: "Gateway System Error",
+    }
+
+    if not message and status:
+        message = messages.get(status, "Unknown error")
+
+    _LOGGER.debug(f"Persist message: {message}")
+
+    if message is None:
+        return
+
+    async_create_notification(
+        hass=hass,
+        message=message,
+        title="Duwi Notification",
+        notification_id="duwi_notification",
+    )
+
+
+def debounce(wait: int or float) -> Callable:
+    """Decorator to debounce function calls.
+
+    Args:
+        wait (int or float): Seconds to wait before the next call to the function can be made.
+
+    Returns:
+        Callable: Decorator for the function.
+    """
+
+    def decorator(fn):
+        async def debounced_fn(self, *args, **kwargs):
+            if hasattr(self, "_debounce_timer") and self._debounce_timer:
+                self._debounce_timer.cancel()
+
+            async def delayed_execution():
+                await asyncio.sleep(wait)
+                await fn(self, *args, **kwargs)
+
+            self._debounce_timer = asyncio.create_task(delayed_execution())
+
+        return debounced_fn
+
+    return decorator

--- a/tests/components/duwi/__init__.py
+++ b/tests/components/duwi/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Duwi component."""

--- a/tests/components/duwi/conftest.py
+++ b/tests/components/duwi/conftest.py
@@ -1,0 +1,95 @@
+"""Define common test fixtures for the Duwi integration."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from duwi_smarthome_sdk.const.status import Code
+
+
+@pytest.fixture
+def mock_duwi_login_auth() -> Generator[AsyncMock, None, None]:
+    """Mock the Duwi login authentication process.
+
+    This fixture simulates the authentication process for the Duwi smart
+    home SDK, returning a success code and mocked tokens for valid credentials,
+    and an error code for invalid ones.
+    """
+
+    async def mock_auth_func(phone: str, password: str):
+        # Simulate successful authentication
+        if phone == "correct_phone" and password == "correct_password":
+            return Code.SUCCESS.value, MagicMock(
+                access_token="mocked_access_token",
+                access_token_expire_time="mocked_access_token_expire_time",
+                refresh_token="mocked_refresh_token",
+                refresh_token_expire_time="mocked_refresh_token_expire_time",
+            )
+        # Simulate failed authentication
+        else:
+            return Code.LOGIN_ERROR.value, None
+
+    with patch(
+        "duwi_smarthome_sdk.api.account.AccountClient.login", new_callable=MagicMock
+    ) as mock_auth:
+        mock_auth.side_effect = mock_auth_func
+        yield mock_auth
+
+
+@pytest.fixture
+def mock_duwi_login_user() -> Generator[AsyncMock, None, None]:
+    """Mock the Duwi user login process.
+
+    This fixture is intended to simulate different login responses based on
+    the provided application key and secret.
+    """
+
+    async def mock_login_func(app_key: str, app_secret: str):
+        # Define login logic simulation based on app_key and app_secret combinations
+        if app_key == "correct_app_key" and app_secret == "correct_app_secret":
+            return Code.SUCCESS.value
+        elif app_key == "error_app_key" and app_secret == "correct_app_secret":
+            return Code.APP_KEY_ERROR.value
+        elif app_key == "correct_app_key" and app_secret == "error_app_secret":
+            return Code.SIGN_ERROR.value
+
+    with patch(
+        "duwi_smarthome_sdk.api.account.AccountClient.auth", new_callable=MagicMock
+    ) as mock_login:
+        mock_login.side_effect = mock_login_func
+        yield mock_login
+
+
+@pytest.fixture
+def mock_duwi_login_select_house() -> Generator[AsyncMock, None, None]:
+    """Mock the Duwi house selection control process.
+
+    This fixture mimics the house selection process, providing a simulated
+    list of house information.
+    """
+
+    async def mock_select_house_func():
+        # Simulate house selection response
+        return Code.SUCCESS.value, [
+            MagicMock(
+                house_no="house_nos_123",
+                house_name="house_name_123",
+                house_image_url="house_image_url_123",
+                address="address_123",
+                location="location_123",
+                seq=1,
+                create_time="create_time_123",
+                deliver_time="deliver_time_123",
+                host_count=1,
+                device_count=1,
+                lan_secret_key="lan_secret_key_123",
+            )
+        ]
+
+    with patch(
+        "duwi_smarthome_sdk.api.house.HouseInfoClient.fetch_house_info",
+        new_callable=MagicMock,
+    ) as mock_select_house:
+        mock_select_house.side_effect = mock_select_house_func
+        yield mock_select_house

--- a/tests/components/duwi/snapshots/test_config_flow.ambr
+++ b/tests/components/duwi/snapshots/test_config_flow.ambr
@@ -1,0 +1,77 @@
+# serializer version: 1
+# name: test_user_flow_auth_failed
+  FlowResultSnapshot({
+    'data_schema': list([
+      dict({
+        'name': 'app_key',
+        'required': True,
+        'type': 'string',
+      }),
+      dict({
+        'name': 'app_secret',
+        'required': True,
+        'type': 'string',
+      }),
+    ]),
+    'description_placeholders': None,
+    'errors': dict({
+    }),
+    'flow_id': <ANY>,
+    'handler': 'duwi',
+    'last_step': None,
+    'preview': None,
+    'step_id': 'user',
+    'type': <FlowResultType.FORM: 'form'>,
+  })
+# ---
+# name: test_user_flow_auth_failed.1
+  FlowResultSnapshot({
+    'data_schema': list([
+      dict({
+        'name': 'phone',
+        'required': True,
+        'type': 'string',
+      }),
+      dict({
+        'name': 'password',
+        'required': True,
+        'type': 'string',
+      }),
+    ]),
+    'description_placeholders': None,
+    'errors': dict({
+    }),
+    'flow_id': <ANY>,
+    'handler': 'duwi',
+    'last_step': None,
+    'preview': None,
+    'step_id': 'auth',
+    'type': <FlowResultType.FORM: 'form'>,
+  })
+# ---
+# name: test_user_flow_auth_failed.2
+  FlowResultSnapshot({
+    'data_schema': list([
+      dict({
+        'name': 'phone',
+        'required': True,
+        'type': 'string',
+      }),
+      dict({
+        'name': 'password',
+        'required': True,
+        'type': 'string',
+      }),
+    ]),
+    'description_placeholders': None,
+    'errors': dict({
+      'base': 'invalid_auth',
+    }),
+    'flow_id': <ANY>,
+    'handler': 'duwi',
+    'last_step': None,
+    'preview': None,
+    'step_id': 'auth',
+    'type': <FlowResultType.FORM: 'form'>,
+  })
+# ---

--- a/tests/components/duwi/test_config_flow.py
+++ b/tests/components/duwi/test_config_flow.py
@@ -1,0 +1,119 @@
+"""Define integration configuration flow tests for the Duwi integration."""
+
+from __future__ import annotations
+
+from homeassistant import config_entries
+from homeassistant.components.duwi.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+
+@pytest.mark.usefixtures(
+    "mock_duwi_login_user", "mock_duwi_login_auth", "mock_duwi_login_select_house"
+)
+async def test_user_flow_success(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the configuration flow: successful path.
+
+    This simulates a user going through the configuration flow, including
+    providing correct credentials and selecting a house, leading to a successful
+    creation of a config entry.
+    """
+    # Start by initializing the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "user"},
+    )
+    # Ensure we're being prompted for initial information
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "user"
+
+    # Simulate submitting the app credentials step
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"app_key": "correct_app_key", "app_secret": "correct_app_secret"},
+    )
+    # Ensure the next step is the authentication stage
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("step_id") == "auth"
+
+    # Next, simulate submitting the phone and password
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"phone": "correct_phone", "password": "correct_password"},
+    )
+    # Move to selecting a house
+    assert result3.get("type") == FlowResultType.FORM
+    assert result3.get("step_id") == "select_house"
+
+    # Finally, simulate selecting a house
+    result4 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"house_no": "house_nos_123"},
+    )
+    # The flow should now complete with a CREATE_ENTRY result
+    assert result4.get("type") == FlowResultType.CREATE_ENTRY
+
+
+@pytest.mark.usefixtures("mock_duwi_login_user")
+async def test_user_flow_user_failed(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the configuration flow: invalid user input.
+
+    This simulates the user providing incorrect app credentials,
+    which should result in repeating the initial user step.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "user"},
+    )
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == "user"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"app_key": "error_app_key", "app_secret": "error_app_secret"},
+    )
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("step_id") == "user"
+
+
+@pytest.mark.usefixtures("mock_duwi_login_user", "mock_duwi_login_auth")
+async def test_user_flow_auth_failed(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the configuration flow: failed authentication.
+
+    This tests the flow where the user enters correct app credentials,
+    but fails at the authentication (login) step.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result.get("type") == FlowResultType.FORM
+    assert result.get("step_id") == config_entries.SOURCE_USER
+    snapshot.assert_match(result)
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"app_key": "correct_app_key", "app_secret": "correct_app_secret"},
+    )
+    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("step_id") == "auth"
+    snapshot.assert_match(result2)
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"phone": "error_phone", "password": "error_password"},
+    )
+    assert result3.get("type") == FlowResultType.FORM
+    assert result3.get("step_id") == "auth"
+    snapshot.assert_match(result3)

--- a/tests/components/duwi/test_cover.py
+++ b/tests/components/duwi/test_cover.py
@@ -1,0 +1,89 @@
+"""Tests for the Duwi cover entity within the Duwi integration."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+from homeassistant.components.cover import CoverEntityFeature
+from homeassistant.components.duwi import DOMAIN
+from homeassistant.components.duwi.cover import DuwiCover
+from homeassistant.core import HomeAssistant
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture
+async def duwi_hass_config(hass: HomeAssistant):
+    """Create a configuration fixture for Duwi within Home Assistant."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["test_instance"] = {
+        "app_key": "test_app_key",
+        "app_secret": "test_app_secret",
+        "access_token": "test_access_token",
+    }
+    yield
+
+
+@pytest.fixture(autouse=True)
+def mock_dev_patcher():
+    """Mock some Duwi device methods."""
+    with patch(
+        "duwi_smarthome_sdk.api.control.ControlClient.control", autospec=True
+    ) as mock_dev:
+        yield mock_dev
+
+
+@pytest.fixture
+def mock_cover(hass: HomeAssistant, mock_dev_patcher):
+    """Create a mocked Duwi cover object."""
+    return DuwiCover(
+        hass=hass,
+        instance_id="test_instance",
+        unique_id="unique_id",
+        device_name="device_name",
+        device_no="device_no",
+        house_no="house_no",
+        room_name="room_name",
+        floor_name="floor_name",
+        terminal_sequence="terminal_sequence",
+        route_num="route_num",
+        state=True,
+        available=True,
+        position=10,
+        supported_features=CoverEntityFeature.SET_POSITION,
+    )
+
+
+@pytest.mark.usefixtures("duwi_hass_config")
+async def test_open_cover(hass: HomeAssistant, mock_cover):
+    """Test the opening of the cover."""
+    cover = mock_cover
+
+    await cover.async_open_cover()
+    await hass.async_block_till_done()
+
+    assert cover.current_cover_position == 100
+
+
+@pytest.mark.usefixtures("duwi_hass_config")
+async def test_close_cover(hass: HomeAssistant, mock_cover):
+    """Test the closing of the cover."""
+    cover = mock_cover
+
+    await cover.async_close_cover()
+    await hass.async_block_till_done()
+
+    assert cover.current_cover_position == 0
+
+
+@pytest.mark.usefixtures("duwi_hass_config")
+async def test_set_cover_position(hass: HomeAssistant, mock_cover):
+    """Test adjust the cover to a specific position."""
+    cover = mock_cover
+
+    new_position = 50
+    await cover.async_set_cover_position(position=new_position)
+    await hass.async_block_till_done()
+
+    assert cover.current_cover_position == new_position

--- a/tests/components/duwi/test_light.py
+++ b/tests/components/duwi/test_light.py
@@ -1,0 +1,79 @@
+"""Tests for Duwi light entity within the Duwi integration."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+from homeassistant.components.duwi import DOMAIN
+from homeassistant.components.duwi.light import DuwiLight
+from homeassistant.components.light import ColorMode
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Setup a fixture to initialize Home Assistant with test data for Duwi
+@pytest.fixture
+async def duwi_hass_config(hass: HomeAssistant):
+    """Fixture to preconfigure Home Assistant for Duwi device testing."""
+    _LOGGER.debug("Setting up Home Assistant test config for Duwi")
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["test_instance"] = {
+        "app_key": "test_app_key",
+        "app_secret": "test_app_secret",
+        "access_token": "test_access_token",
+    }
+    yield
+
+
+# Autouse fixture to mock device control functions
+@pytest.fixture(autouse=True)
+def mock_dev_patcher():
+    """Fixture that mocks out the Duwi device control API calls."""
+    with patch(
+        "duwi_smarthome_sdk.api.control.ControlClient.control", autospec=True
+    ) as mock_dev:
+        yield mock_dev
+
+
+# Fixture to create and return a mock DuwiLight entity
+@pytest.fixture
+def mock_light(hass: HomeAssistant, mock_dev_patcher):
+    """Generate a mock DuwiLight entity."""
+    return DuwiLight(
+        hass=hass,
+        instance_id="test_instance",
+        unique_id="unique_id",
+        device_name="device_name",
+        device_no="device_no",
+        house_no="house_no",
+        room_name="room_name",
+        floor_name="floor_name",
+        terminal_sequence="terminal_sequence",
+        route_num="route_num",
+        light_type="light_type",
+        effect_list=[],
+        effect_map={},
+        state=True,
+        available=True,
+        supported_color_modes={ColorMode.COLOR_TEMP, ColorMode.HS},
+    )
+
+
+# Tests for validating interaction with the light entity
+@pytest.mark.usefixtures("duwi_hass_config")
+async def test_turn_on(hass: HomeAssistant, mock_light):
+    """Test that the light turns on successfully."""
+    light = mock_light
+    await light.async_turn_on()  # Call turn on method
+    await hass.async_block_till_done()  # Ensure all async methods have completed
+    assert light.is_on  # Verify state of 'is_on' to be True
+
+
+@pytest.mark.usefixtures("duwi_hass_config")
+async def test_turn_off(hass: HomeAssistant, mock_light):
+    """Test that the light turns off successfully."""
+    light = mock_light
+    await light.async_turn_off()  # Call turn off method
+    await hass.async_block_till_done()  # Ensure all async methods have completed
+    assert not light.is_on  # Verify state of 'is_on' to be False

--- a/tests/components/duwi/test_switch.py
+++ b/tests/components/duwi/test_switch.py
@@ -1,0 +1,68 @@
+"""Tests for the Duwi switch entity in Home Assistant."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+from homeassistant.components.duwi import DOMAIN
+from homeassistant.components.duwi.switch import DuwiSwitch
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@pytest.fixture
+async def duwi_hass_config(hass: HomeAssistant):
+    """Set up Duwi devices within Home Assistant."""
+    _LOGGER.info("Initializing DUWI device configuration for testing.")
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["test_instance"] = {
+        "app_key": "test_app_key",
+        "app_secret": "test_app_secret",
+        "access_token": "test_access_token",
+    }
+    yield
+
+
+@pytest.fixture(autouse=True)
+def mock_dev_patcher():
+    """Mock control function for the Duwi device."""
+    with patch(
+        "duwi_smarthome_sdk.api.control.ControlClient.control", autospec=True
+    ) as mock_dev:
+        yield mock_dev
+
+
+@pytest.fixture
+def mock_switch(hass: HomeAssistant, mock_dev_patcher):
+    """Create and provide a mock Duwi switch entity."""
+    return DuwiSwitch(
+        hass=hass,
+        instance_id="test_instance",
+        unique_id="unique_id",
+        device_name="device_name",
+        device_no="device_no",
+        house_no="house_no",
+        room_name="room_name",
+        floor_name="floor_name",
+        terminal_sequence="terminal_sequence",
+        route_num="route_num",
+        state=True,
+        available=True,
+    )
+
+
+@pytest.mark.usefixtures("duwi_hass_config")
+async def test_turn_on(hass: HomeAssistant, mock_switch):
+    """Verify the switch turns on as expected."""
+    await mock_switch.async_turn_on()
+    await hass.async_block_till_done()
+    assert mock_switch.is_on, "Switch should be ON."
+
+
+@pytest.mark.usefixtures("duwi_hass_config")
+async def test_turn_off(hass: HomeAssistant, mock_switch):
+    """Ensure the switch turns off correctly."""
+    await mock_switch.async_turn_off()
+    await hass.async_block_till_done()
+    assert not mock_switch.is_on, "Switch should be OFF."


### PR DESCRIPTION
## Introducing the Duwi Integration: Remote Device Control and State Synchronization

### Problem
Users need a way to control and synchronize the state of their Duwi smart home devices, including switches, lights, and curtains, through Home Assistant.

### Solution
Developed a new Duwi integration that allows users to authenticate with an App Key and secret, log in using their phone number, pull all rooms from the cloud, and integrate these devices into HA. 

### Detailed Changes
- Implemented device categorization for support of switches, lights, and curtains.
- Utilized the Duwi SmartHome SDK for all request handling and WebSocket connections.
- Device states are synchronized using WebSockets, ensuring real-time state updates in HA.
- State changes are pushed to HA and local device states are updated accordingly whenever a device's state changes.

### Impact
This integration offers users a convenient way to incorporate their Duwi devices into Home Assistant without disrupting existing configurations.

### Testing
- Created test suites covering device setup flow and operations for switches, lights, and curtains.
- All test cases have passed, ensuring the stability of the code and the efficacy of the functionalities.

### Additional Notes
Strict adherence to official documentation for coding standards has been maintained, with all code undergoing appropriate style and standards checks.

Please review @maintainer